### PR TITLE
Fix for python 3

### DIFF
--- a/atsge/SGEJobSubmitter.py
+++ b/atsge/SGEJobSubmitter.py
@@ -137,6 +137,7 @@ class SGEJobSubmitter(object):
             job_desc.split(),
             stdout = subprocess.PIPE,
             stderr = subprocess.PIPE,
+            universal_newlines = True,
         )
         stdout, stderr = proc.communicate()
 
@@ -228,7 +229,8 @@ class SGEJobSubmitter(object):
             proc = subprocess.Popen(
                 procargs,
                 stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE
+                stderr=subprocess.PIPE,
+                universal_newlines=True,
             )
             stdout, stderr = proc.communicate()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
-alphatwirl==0.25.2
-atpbar==1.0.3
-coverage==4.5.3
-pytest==4.3.0
-pytest-cov==2.6.1
+alphatwirl>=0.25.2
+atpbar>=1.0.3


### PR DESCRIPTION
Backwards compatible subprocess option `universal_newlines=True` to decode stdout and stderr from running bash commands through subprocess